### PR TITLE
Fix issue with serialization of datetime.date objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,16 +3,27 @@
 Changes
 -------
 
+0.8.4 (2019-08-22)
+++++++++++++++++++
+
+**Bug Fixes**
+
+- Fixes issue with serialization of datetime.date objects `#284 <https://github.com/Geotab/mygeotab-python/pull/284>`__.
+
+
 0.8.3 (2019-08-19)
 ++++++++++++++++++
 
 **Improvements**
+
 - Use the high-performance `python-rapidjson <https://github.com/python-rapidjson/python-rapidjson>`__ library to serialize and deserialize JSON parameters and responses in Python 3.5+ `#268 <https://github.com/Geotab/mygeotab-python/pull/268>`__. 
 
 **Bug Fixes**
+
 - Silence warnings from arrow parsing when the library is used interactively or in a Jupyter notebook.
 
 **Housecleaning**
+
 - Added serialization benchmarking in CircleCI tests.
 - Remove PyPy test config.
 
@@ -20,6 +31,7 @@ Changes
 ++++++++++++++++++
 
 **Bug Fixes**
+
 - Remove asyncio-specific default arguments preventing from importing this pacakge in a Python 3.5+ thread `#236 <https://github.com/Geotab/mygeotab-python/issues/236>`__.
 
 0.8.1 (2019-06-03)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,15 @@
 include LICENSE
+include CHANGELOG.rst
+include README.rst
+include tox.ini
+include pytest.ini
+include Pipfile
+include Pipfile.lock
+include pyproject.toml
 
 graft docs
 graft examples
 graft mygeotab
 graft tests
+
+global-exclude *.py[co] .DS_Store

--- a/mygeotab/dates.py
+++ b/mygeotab/dates.py
@@ -19,11 +19,13 @@ MAX_DATE = pytz.utc.localize(datetime(9999, 12, 31, 23, 59, 59, 999999))
 def format_iso_datetime(datetime_obj):
     """Formats the given datetime as a UTC-zoned ISO 8601 date string.
 
-    :param datetime_obj: The datetime object.
+    :param datetime_obj: The datetime or date object.
     :type datetime_obj: datetime
     :return: The datetime object in 8601 string form.
     :rtype: datetime
     """
+    if not isinstance(datetime_obj, datetime):
+        return datetime_obj.isoformat()
     datetime_obj = localize_datetime(datetime_obj, pytz.utc)
     if datetime_obj < MIN_DATE:
         datetime_obj = MIN_DATE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,11 @@
-[wheel]
+[metadata]
+license_file = LICENSE
+
+[bdist_wheel]
 universal = 1
+
+[tool:pytest]
+testpaths = tests
 
 [flake8]
 ignore = E402

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,12 @@ setup(
     package_data={"": ["LICENSE"]},
     license="Apache 2.0",
     install_requires=["requests", "click", "pytz", "arrow", "six"],
+    setup_requires=["wheel"],
     entry_points="""
         [console_scripts]
         myg=mygeotab.cli:main
     """,
-    classifiers=(
+    classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Natural Language :: English",
@@ -62,5 +63,5 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries",
-    ),
+    ],
 )

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
-from datetime import datetime
+from datetime import date, datetime
 
 import pytz
 
@@ -23,15 +23,22 @@ class TestSerialization:
         data_str = json_serialize(data)
         assert data_str == expected_str
 
-    def test_min_date(self):
+    def test_min_datetime(self):
         data = dict(dateTime=dates.MIN_DATE)
         expected_str = '{"dateTime":"0001-01-01T00:00:00.000Z"}'
         data_str = json_serialize(data)
         assert data_str == expected_str
 
-    def test_max_date(self):
+    def test_max_datetime(self):
         data = dict(dateTime=dates.MAX_DATE)
         expected_str = '{"dateTime":"9999-12-31T23:59:59.999Z"}'
+        data_str = json_serialize(data)
+        assert data_str == expected_str
+
+    def test_only_date(self):
+        this_date = date(2016, 2, 22)
+        data = dict(date=this_date)
+        expected_str = '{"date":"2016-02-22"}'
         data_str = json_serialize(data)
         assert data_str == expected_str
 


### PR DESCRIPTION
Issue when serializing POST params with a datetime.date object:

```
'datetime.date' object has no attribute 'tzinfo'
```