### PR TITLE
Prevent serialization of duration strings into datetime.time objects

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -91,3 +91,27 @@ class TestDeserialization:
         assert utc_date.year == check_date.year
         assert utc_date.month == check_date.month
         assert utc_date.day == check_date.day
+
+    def test_duration(self):
+        duration_str = "12:49:24.004000"
+        data_str = '{{"duration": "{}"}}'.format(duration_str)
+        data = json_deserialize(data_str)
+        duration = data.get("duration")
+        assert duration is not None
+        assert duration == duration_str
+
+    def test_duration_with_name(self):
+        duration_str = "02:33:24.004403"
+        data_str = '{{"drivingDuration": "{}"}}'.format(duration_str)
+        data = json_deserialize(data_str)
+        duration = data.get("drivingDuration")
+        assert duration is not None
+        assert duration == duration_str
+
+    def test_long_duration(self):
+        duration_str = "2.12:49:24.004000"
+        data_str = '{{"duration": "{}"}}'.format(duration_str)
+        data = json_deserialize(data_str)
+        duration = data.get("duration")
+        assert duration is not None
+        assert duration == duration_str


### PR DESCRIPTION
Fixes #333 by preventing serialization of duration objects in the format HH:MM:SS.ffffffff to `datetime.time` objects