### PR TITLE
Update default database value in initialization

### DIFF
--- a/mygeotab/api.py
+++ b/mygeotab/api.py
@@ -35,7 +35,7 @@ class API(object):
         self,
         username,
         password=None,
-        database=None,
+        database="",
         session_id=None,
         server="my.geotab.com",
         timeout=DEFAULT_TIMEOUT,


### PR DESCRIPTION
Ostensibly due to a recent server-side code change, authentication breaks if `database` is left as `None` when sending an authentication request. However, leaving the `database` as an empty string seems to provide the intended effect of successfully authenticating and allowing the database to be reassigned upon authentication.