### PR TITLE
Fix sort parameter handling

### DIFF
--- a/mygeotab/api.py
+++ b/mygeotab/api.py
@@ -179,10 +179,14 @@ class API(object):
                 if results_limit is not None:
                     del parameters["results_limit"]
 
+            sort = parameters.get("sort")
+            if sort is not None:
+                del parameters["sort"]
+
             if "search" in parameters:
                 parameters.update(parameters["search"])
                 del parameters["search"]
-            parameters = dict(search=parameters, resultsLimit=results_limit)
+            parameters = dict(search=parameters, resultsLimit=results_limit, sort=sort)
         return self.call("Get", type_name=type_name, **parameters)
 
     def add(self, type_name, entity):


### PR DESCRIPTION
The `sort` parameter is mishandled in the API class in that it is entirely ignored, leading to it becoming part of the `search` dict. This, in turn, makes it non-functional. This PR fixes this in the same way that the `result_limit` property is handled.

In the current implementation, the resulting param set looks like this:
```py
{
    "id": -1,
    "method": "Get",
    "params": {
        "search": {
            "sort": {"sortBy": "date", "sortDirection": "desc", "offset": None, "lastId": None},
            "deviceSearch": {"id": "<myID>"},
        },
        "resultsLimit": 3,
        "typeName": "DriverChange",
        "credentials": <removed>,
    },
}
```