### PR TITLE
Surface GBQ errors during getJobStatus stage

### DIFF
--- a/mygeotab/altitude/daas_definition.py
+++ b/mygeotab/altitude/daas_definition.py
@@ -77,6 +77,17 @@ class DaasGetJobStatusResult(DaasResult):
         self.status = self.job.get("status", {"state": "FAILED"})
         self.state = self.status.get("state", "FAILED")
 
+        error_result = self.status.get("errorResult")
+        if error_result:
+            self.api_result_error = DaasError({
+                "code": error_result.get("code", 500),
+                "domain": error_result.get("location", ""),
+                "message": error_result.get("message", "Job completed with error"),
+            })
+            self.errors.append(Exception(self.api_result_error.message))
+            self.state = "FAILED"
+
+
     def has_finished(self):
         if self.state == "DONE":
             return True


### PR DESCRIPTION
## Summary
- Surface BigQuery `errorResult` returned during the `getJobStatus` stage so failures are reported instead of silently passing through.
- When a job's status contains an `errorResult`, build a `DaasError` from its code/location/message, append it to `errors`, and force the state to `FAILED`.

## Test plan
- [ ] Verify a job that finishes with a BigQuery `errorResult` is reported as `FAILED` with the error surfaced.
- [ ] Verify a successful job (no `errorResult`) still resolves normally.